### PR TITLE
修正: コンソールへ出力されない時がある

### DIFF
--- a/src/Pv/PvPf_Windows.hpp
+++ b/src/Pv/PvPf_Windows.hpp
@@ -147,7 +147,9 @@ extern void pvPfIoClose(PvPfFileInfo& fileInfo);
 extern size_t pvPfCccUtf8ToUtf16(char16_t* convertedBuffer, const size_t bufLength, const char8_t* source, const size_t sourceLength);
 extern size_t pvPfCccMultiByteToUtf16(char16_t* convertedBuffer, const size_t bufLength, const char* source, const size_t sourceLength, const unsigned int codePage);
 extern size_t pvPfCccUtf16ToUtf8(char8_t* convertedBuffer, size_t bufLength, const char16_t* source, const size_t sourceLength);
+extern size_t pvPfCccUtf16ToMultiByte(char* convertedBuffer, size_t bufLength, const char16_t* source, const size_t sourceLength, const unsigned int codePage);
 extern size_t pvPfCccMultiByteToUtf8(char8_t* convertedBuffer, size_t bufLength, const char* source, const size_t sourceLength, const unsigned int codePage);
+extern size_t pvPfCccUtf8ToMultiByte(char* convertedBuffer, size_t bufLength, const char8_t* source, const size_t sourceLength, const unsigned int codePage);
 extern unsigned int pvPfCccGetCodePageFromName(const char8_t* codePageName);
 
 extern PvPfWindowHandle pvPfCreateWindow(const char8_t* windowTitle, PvPfWindowEventOperator& eventInfo);

--- a/testing/PvPfCccTests.cpp
+++ b/testing/PvPfCccTests.cpp
@@ -126,6 +126,106 @@ TEST(PvPfCcc_Windows, pvPfCccUtf8ToUtf16_invalid_operation)
     ASSERT_NO_THROW(pvPfShutdown());
 }
 
+TEST(PvPfCcc_Windows, pvPfCccUtf16ToUtf8_correct)
+{
+    ASSERT_NO_THROW(pvPfInitialize(ApplicationInstance));
+    {
+        const char8_t* u8expected = u8"あいうえお𠮷今晩わ💕";
+        const auto u8expectedLength = strnlen_s(reinterpret_cast<char const*>(u8expected), 128);
+        const char16_t* u16str = u"あいうえお𠮷今晩わ💕";
+        const auto u16strLength = wcsnlen_s(reinterpret_cast<wchar_t const*>(u16str), 128);
+        constexpr auto u8strLength = 128;
+        std::unique_ptr<char8_t[]> u8str = std::make_unique<char8_t[]>(u8strLength);
+
+        EXPECT_EQ(pvPfCccUtf16ToUtf8(u8str.get(), u8strLength, u16str, u16strLength), u8expectedLength + 1);
+        EXPECT_EQ(strncmp(reinterpret_cast<char const*>(u8expected), reinterpret_cast<const char*>(u8str.get()),
+            u8strLength),
+            0);
+    }
+    {
+        const char8_t* u8expected = u8"あいうえお𠮷今晩わ💕";
+        const auto u8expectedLength = strnlen_s(reinterpret_cast<char const*>(u8expected), 128);
+        const char16_t* u16str = u"あいうえお𠮷今晩わ💕";
+        const auto u16strLength = wcsnlen_s(reinterpret_cast<wchar_t const*>(u16str), 128);
+
+        constexpr auto u8strLength = 128;
+        std::unique_ptr<char8_t[]> u8str = std::make_unique<char8_t[]>(u8strLength);
+        auto u8char = u8str[0];
+
+        EXPECT_EQ(pvPfCccUtf16ToUtf8(nullptr, u8strLength, u16str, u16strLength), u8expectedLength + 1);
+        EXPECT_EQ(pvPfCccUtf16ToUtf8(u8str.get(), 0, u16str, u16strLength), u8expectedLength + 1);
+        EXPECT_EQ(u8str[0] == u8char, true);
+    }
+    {
+        const char8_t* u8expected = u8"";
+        const auto u8expectedLength = strnlen_s(reinterpret_cast<char const*>(u8expected), 128);
+        const char16_t* u16str = u"";
+        const auto u16strLength = wcsnlen_s(reinterpret_cast<wchar_t const*>(u16str), 128);
+        constexpr auto u8strLength = 128;
+        std::unique_ptr<char8_t[]> u8str = std::make_unique<char8_t[]>(u8strLength);
+
+        EXPECT_EQ(pvPfCccUtf16ToUtf8(u8str.get(), u8strLength, u16str, u8strLength), u8expectedLength);
+        EXPECT_EQ(strncmp(reinterpret_cast<char const*>(u8expected), reinterpret_cast<const char*>(u8str.get()),
+            u8strLength),
+            0);
+    }
+    ASSERT_NO_THROW(pvPfShutdown());
+}
+
+TEST(PvPfCcc_Windows, pvPfCccUtf16ToUtf8_u16_dest_buffer_too_small)
+{
+    ASSERT_NO_THROW(pvPfInitialize(ApplicationInstance));
+
+    const char16_t* u16str = u"あいうえお𠮷今晩わ💕";
+    const auto u16strLength = wcsnlen_s(reinterpret_cast<wchar_t const*>(u16str), 128);
+    constexpr auto u8strLength = 4;
+    std::unique_ptr<char8_t[]> u8str = std::make_unique<char8_t[]>(u8strLength);
+
+    EXPECT_EQ(pvPfCccUtf16ToUtf8(u8str.get(), u8strLength, u16str, u16strLength), 0);
+    ASSERT_NO_THROW(pvPfShutdown());
+}
+
+TEST(PvPfCcc_Windows, pvPfCccUtf16ToUtf8_invalid_operation)
+{
+    ASSERT_NO_THROW(pvPfInitialize(ApplicationInstance));
+    {
+        const char16_t* u16str = u"あいうえお𠮷今晩わ💕";
+        const auto u16strLength = wcsnlen_s(reinterpret_cast<wchar_t const*>(u16str), 128);
+        constexpr auto u8strLength = 128;
+        std::unique_ptr<char8_t[]> u8str = std::make_unique<char8_t[]>(u8strLength);
+
+        EXPECT_EQ(pvPfCccUtf16ToUtf8(u8str.get(), u8strLength, nullptr, u16strLength), 0);
+    }
+    {
+        const char16_t* u16str = u"あいうえお𠮷今晩わ💕";
+        constexpr auto u8strLength = 128;
+        std::unique_ptr<char8_t[]> u8str = std::make_unique<char8_t[]>(u8strLength);
+
+        EXPECT_EQ(pvPfCccUtf16ToUtf8(u8str.get(), u8strLength, u16str, 0), 0);
+    }
+
+    ASSERT_NO_THROW(pvPfShutdown());
+}
+
+TEST(PvPfCcc_Windows, pvPfCccUtf16ToMultiBytes_correct)
+{
+    ASSERT_NO_THROW(pvPfInitialize(ApplicationInstance));
+    {
+        const char* mbexpected = "あいうえお𠮷今晩わ💕";
+        const auto mbexpectedLength = strnlen_s(reinterpret_cast<char const*>(mbexpected), 128);
+        const char16_t* u16str = u"あいうえお𠮷今晩わ💕";
+        const auto u16strLength = wcsnlen_s(reinterpret_cast<wchar_t const*>(u16str), 128);
+        constexpr auto mbstrLength = 128;
+        std::unique_ptr<char[]> mbstr = std::make_unique<char[]>(mbstrLength);
+
+        EXPECT_EQ(pvPfCccUtf16ToMultiByte(mbstr.get(), mbstrLength, u16str, u16strLength, CP_ACP), mbexpectedLength + 1);
+        EXPECT_EQ(strncmp(mbexpected, mbstr.get(),
+            mbstrLength),
+            0);
+    }
+    ASSERT_NO_THROW(pvPfShutdown());
+}
+
 TEST(PvPfCcc_Windows, pvPfCccMultiByteToUtf8_sjis_correct)
 {
     ASSERT_NO_THROW(pvPfInitialize(ApplicationInstance));


### PR DESCRIPTION
# 内容

修正: コンソールへ出力する文字列を UTF-16 ではなくアクティブコードページに基づくマルチバイト文字とする
追加: pvPfCccUtf8ToMultiByte()
追加: pvPfCccUtf16ToMultiByte()
追加: テストケース

# 関連Issue

#6 