### PR TITLE
修正: 運転台パネルファイルで指定している透過色が無視される

### DIFF
--- a/src/Pv/PvInstrumentPanelDocumentDataNode.hpp
+++ b/src/Pv/PvInstrumentPanelDocumentDataNode.hpp
@@ -425,6 +425,8 @@ protected:
         G = std::clamp(G, 0.0, 1.0);
         R = std::clamp(R, 0.0, 1.0);
 
+        A = 1.0;
+
         return true;
     }
 
@@ -615,7 +617,7 @@ public:
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Value<u8"Bottom"> Bottom;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Path<u8"DaytimeImage"> DaytimeImage;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Path<u8"NighttimeImage"> NighttimeImage;
-    PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor"> TransparentColor;
+    PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor"> TransparentColor = PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor">(0.0, 0.0, 0.0, 0.0);
     PvInstrumentPanelDocumentDataTypeKeyValuePair_ValueArray<u8"Center", 2> Center;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_ValueArray<u8"Origin", 2> Origin;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Value<u8"Perspective"> Perspective;
@@ -645,7 +647,7 @@ public:
     PvInstrumentPanelDocumentDataTypeKeyValuePair_ValueArray<u8"Location", 2> Location;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Path<u8"DaytimeImage"> DaytimeImage;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Path<u8"NighttimeImage"> NighttimeImage;
-    PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor"> TransparentColor;
+    PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor"> TransparentColor = PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor">(0.0, 0.0, 0.0, 0.0);
     PvInstrumentPanelDocumentDataTypeKeyValuePair_RenderingOrder<u8"Layer"> Layer;
 };
 
@@ -685,7 +687,7 @@ public:
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Path<u8"DaytimeImage"> DaytimeImage;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Path<u8"NighttimeImage"> NighttimeImage;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"Color"> Color = PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"Color">(1.0,1.0,1.0,1.0);
-    PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor"> TransparentColor;
+    PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor"> TransparentColor = PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor">(0.0, 0.0, 0.0, 0.0);
     PvInstrumentPanelDocumentDataTypeKeyValuePair_ValueArray<u8"Origin", 2> Origin;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_RenderingOrder<u8"Layer"> Layer;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Value<u8"Radius"> Radius;
@@ -762,7 +764,7 @@ public:
     PvInstrumentPanelDocumentDataTypeKeyValuePair_ValueArray<u8"Location", 2> Location;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Path<u8"DaytimeImage"> DaytimeImage;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Path<u8"NighttimeImage"> NighttimeImage;
-    PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor"> TransparentColor;
+    PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor"> TransparentColor = PvInstrumentPanelDocumentDataTypeKeyValuePair_Color<u8"TransparentColor">(0.0, 0.0, 0.0, 0.0);
     PvInstrumentPanelDocumentDataTypeKeyValuePair_RenderingOrder<u8"Layer"> Layer;
     PvInstrumentPanelDocumentDataTypeKeyValuePair_Value<u8"Interval"> Interval;
 };

--- a/src/Pv/PvInstrumentPanelGenerator.cpp
+++ b/src/Pv/PvInstrumentPanelGenerator.cpp
@@ -85,7 +85,7 @@ namespace
 
         if (pvPfIoRead(fileInfo))
         {
-            auto newTexture = pvGrGenerateTextureFromFile(grContext, fileInfo);
+            auto newTexture = pvGrGenerateTextureFromFile(grContext, fileInfo, component.GetTransparentColor());
             component.SetTexture(newTexture, usage);
             workData.RegisterTextureToCache(newTexture, fileInfo.GetPath());
         }
@@ -108,6 +108,8 @@ namespace
             thisObject.SetTopMax(thisNode.Top.Value);
             thisObject.SetRightMax(thisNode.Right.Value);
             thisObject.SetBottomMax(thisNode.Bottom.Value);
+            thisObject.SetTransparentColor(thisNode.TransparentColor.A, thisNode.TransparentColor.R, 
+                                           thisNode.TransparentColor.G, thisNode.TransparentColor.B);
             thisObject.SetCenter({thisNode.Center.Value[0], thisNode.Center.Value[1]});
             thisObject.SetOrigin({thisNode.Origin.Value[0], thisNode.Origin.Value[1]});
             thisObject.SetPerspective(thisNode.Perspective.Value);


### PR DESCRIPTION
# 内容

修正: [this] が TransparentColor を読み飛ばしていたので正しく設定するようにする
修正: TransparentColor の初期値が 0xFF000000 となっていたので 0x00000000 として無効となるようにする
修正: TransparentColor がテクスチャ読み込みの際に使われていなかったので、使うようにする

# 関連Issue

#13 