### PR TITLE
修正: subjectKey の hour, min の扱いが Bve と異なる

### DIFF
--- a/src/Pv/PvInstrumentPanelComponent_ParametricObjectBase.hpp
+++ b/src/Pv/PvInstrumentPanelComponent_ParametricObjectBase.hpp
@@ -188,15 +188,15 @@ protected:
 
             case PvInstrumentPanelSubjectKeyTitle_Hour:
                 {
-                    constexpr auto div = 1000 * 3600;
-                    const auto value = updateInfo.Time / div;
+                    constexpr auto div = 1000.0 * 3600.0;
+                    const auto value = static_cast<double>(updateInfo.Time) / div;
                     SetParameter(value);
                 }
                 break;
             case PvInstrumentPanelSubjectKeyTitle_Min:
                 {
-                    constexpr auto div = 1000 * 60;
-                    const auto value = updateInfo.Time / div;
+                    constexpr auto div = 1000.0 * 60.0;
+                    const auto value = static_cast<double>(updateInfo.Time) / div;
                     SetParameter(value);
                 }
                 break;


### PR DESCRIPTION
# 内容

修正: subjectKey の hour, min の扱いが整数値となっていた、正しくは実数値

# 関連Issue

#21 